### PR TITLE
Adding comment management

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -1,0 +1,66 @@
+/**
+ * Convert character position to line/column position
+ * @param {string} source - The source code
+ * @param {number} charPos - Character position
+ * @returns {{ line: number, column: number }}
+ */
+function charPosToLineCol(source, charPos) {
+	let line = 1;
+	let column = 0;
+	
+	for (let i = 0; i < charPos && i < source.length; i++) {
+		if (source[i] === '\n') {
+			line++;
+			column = 0;
+		} else {
+			column++;
+		}
+	}
+	
+	return { line, column };
+}
+
+/**
+ * Add loc property to oxc-parser comments
+ * @param {any[]} comments - Comments from oxc-parser
+ * @param {string} source - Source code
+ * @returns {any[]} Comments with loc property
+ */
+export function addLocToComments(comments, source) {
+	return comments.map(comment => ({
+		...comment,
+		loc: {
+			start: charPosToLineCol(source, comment.start),
+			end: charPosToLineCol(source, comment.end)
+		}
+	}));
+}
+
+/**
+ * Add loc property to all AST nodes
+ * @param {any} node - AST node
+ * @param {string} source - Source code
+ */
+export function addLocToASTNodes(node, source) {
+	if (!node || typeof node !== 'object') return;
+	
+	// Add loc property if the node has start/end positions
+	if (typeof node.start === 'number' && typeof node.end === 'number') {
+		node.loc = {
+			start: charPosToLineCol(source, node.start),
+			end: charPosToLineCol(source, node.end)
+		};
+	}
+	
+	// Recursively process all properties
+	for (const key in node) {
+		if (key === 'loc') continue; // Skip the loc property we just added
+		const value = node[key];
+		
+		if (Array.isArray(value)) {
+			value.forEach(item => addLocToASTNodes(item, source));
+		} else if (value && typeof value === 'object') {
+			addLocToASTNodes(value, source);
+		}
+	}
+}

--- a/test/esrap.test.js
+++ b/test/esrap.test.js
@@ -8,6 +8,7 @@ import { print } from '../src/index.js';
 import { acornTs, acornTsx, load } from './common.js';
 import tsx from '../src/languages/tsx/index.js';
 import { parseSync } from 'oxc-parser';
+import { addLocToASTNodes, addLocToComments } from '../src/comments.js';
 
 /** @param {TSESTree.Node} ast */
 function clean(ast) {
@@ -101,6 +102,12 @@ for (const dir of fs.readdirSync(`${__dirname}/samples`)) {
 				// @ts-expect-error
 				experimentalRawTransfer: true
 			}));
+
+			// Add loc property to comments
+			oxc_comments = addLocToComments(oxc_comments, input_js);
+
+			// Add loc property to all AST nodes
+			addLocToASTNodes(oxc_ast, input_js);
 
 			opts = {
 				sourceMapSource: 'input.js',


### PR DESCRIPTION
~I added `addLocToComments` and `addLocToASTNodes` in tests to see. But it's probably not here that we will want it.~

~More tests are passing :)~

~I think that there is 2 things left:~
~- a few blank lines are missing. (I also have another fix, but it's changing a LOT of tests... (in probably a better way... But I do another [PR](https://github.com/manuel3108/esrap/pull/2) to see the diff ;) ))~
- some extra optional  `(` and `)` was removed with `acorn`, but preserved with `oxc`. Not sure what to do there... Probably not a big deal.

---

The issue with this... Is that I'm parsing again the file! 🤣
And we don't want this ;)

At least I'm learning stuff ;)